### PR TITLE
correct branch name for formatter action

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -2,9 +2,9 @@ name: code formatting
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   lint:


### PR DESCRIPTION
Now GitHub will run the `black` formatter on PRs!